### PR TITLE
ci: add explicit contents:read permissions to workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,6 +1,9 @@
 name: Bandit
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Bandit Validation

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,9 @@
 name: Black
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Black Validation

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Coverage Validation

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,6 +1,9 @@
 name: Isort
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Isort Validation

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,9 @@
 name: Mypy
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Mypy Validation

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,9 @@
 name: Pylint
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Pylint Validation

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,9 @@
 name: Pytest
 on: [ pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Pytest Validation


### PR DESCRIPTION
Adds least-privilege `permissions` blocks to all CI workflows that lacked them.

Closes #52